### PR TITLE
fix: Proper lib references [WIP]

### DIFF
--- a/contracts/ERC2222.sol
+++ b/contracts/ERC2222.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.6.11;
 
-import "lib/openzeppelin-contracts/contracts/token/ERC20/SafeERC20.sol";
-import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
-import "lib/openzeppelin-contracts/contracts/math/SafeMath.sol";
-import "lib/openzeppelin-contracts/contracts/math/SignedSafeMath.sol";
+import "openzeppelin-contracts/token/ERC20/SafeERC20.sol";
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/math/SafeMath.sol";
+import "openzeppelin-contracts/math/SignedSafeMath.sol";
 import "./IERC2222.sol";
 import "./math/UintSafeMath.sol";
 import "./math/IntSafeMath.sol";


### PR DESCRIPTION
Just fixed `openzeppelin-contracts` iib referencing to not break upstream dapp installs/imports.